### PR TITLE
컴플레인 페이지에 history 보기 기능 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,8 @@ import TimeFocusSelectPage from './pages/TimeFocusSelectPage';
 import QrCheckInPage from './pages/QrCheckInPage';
 import SimultaneousSelectPage from './pages/SimultaneousSelectPage';
 import ComplaintPage from './pages/ComplaintPage';
-
+import ComplaintMenuPage from './pages/ComplaintMenuPage';
+import ComplaintHistoryPage from './pages/ComplaintHistoryPage';
 //url 분석 (무조건 main page로 가지 않게 하기 위함) & login이 매 새로고침마다 풀리는 문제 해결
 const getInitialState = () => {
   const path = window.location.pathname;
@@ -76,6 +77,10 @@ function App() {
         return <SimultaneousSelectPage onNavigate={setPage} />;
       case 'complaintPage':
         return <ComplaintPage onNavigate={setPage} />;
+      case 'complaintMenuPage':
+        return <ComplaintMenuPage onNavigate={setPage} />
+      case 'complaintHistoryPage':
+        return <ComplaintHistoryPage onNavigate={setPage} />
       default:
         return <LoginPage onNavigate={setPage} />; //default를 login page로 수정
     }

--- a/src/pages/ComplaintHistoryPage.css
+++ b/src/pages/ComplaintHistoryPage.css
@@ -1,0 +1,398 @@
+/* ComplaintHistoryPage.css */
+
+/* 1. 페이지 전체 레이아웃 (BookingHistoryPage 스타일 재사용) */
+.history-page-container {
+    font-family: 'Noto Sans KR', Arial, sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 3rem 2rem;
+    background-color: #ffffff;
+    min-height: 100vh;
+    box-sizing: border-box;
+    position: relative;
+}
+
+/* 2. '뒤로가기' 버튼 (BookingHistoryPage 스타일 재사용) */
+.back-button {
+    position: absolute;
+    top: 1.5rem;
+    left: 1.5rem;
+    z-index: 10;
+    padding: 0.6rem 1.2rem;
+    background-color: #f8f9fa;
+    color: #333;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
+    transition: all 0.3s ease;
+}
+
+.back-button:hover {
+    background-color: #ffffff;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+}
+
+/* 3. 헤더 (페이지 제목 - ComplaintPage 스타일 참고) */
+.top-title {
+    width: 100%;
+    text-align: center;
+    margin-bottom: 3rem;
+    padding-top: 2.5rem;
+}
+
+.page-title {
+    color: #004B8D;
+    /* 인하대 메인 색상 */
+    font-size: 2.25rem;
+    margin-bottom: 0;
+    font-weight: 700;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* 4. 메인 콘텐츠 (테이블) 컨테이너 (BookingHistoryPage 스타일 재사용) */
+.history-container {
+    width: 100%;
+    max-width: 1000px;
+    background-color: #ffffff;
+    padding: 2rem 2.5rem;
+    border-radius: 16px;
+    border: 1px solid #e9ecef;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.03);
+    box-sizing: border-box;
+}
+
+.table-center-box {
+    width: 100%;
+    overflow-x: auto;
+}
+
+/* 5. 예약 내역 테이블 (BookingHistoryPage 스타일 재사용) */
+.history-table {
+    width: 100%;
+    margin: 0;
+    border-collapse: collapse;
+    background: none;
+    box-sizing: border-box;
+    min-width: 700px;
+}
+
+.history-table th,
+.history-table td {
+    border-bottom: 1px solid #f0f0f0;
+    padding: 1rem;
+    text-align: center;
+    font-size: 0.95rem;
+    box-sizing: border-box;
+    background-color: #fff;
+    white-space: nowrap;
+}
+
+.history-table th {
+    background-color: #f8f9fa;
+    color: #333;
+    font-weight: 600;
+    font-size: 1rem;
+    border-top: 1px solid #e9ecef;
+}
+
+.history-table tbody tr {
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.history-table tbody tr:hover {
+    background-color: #f7faff;
+}
+
+/* 6. 상태 배지 (Status Badge) */
+.status-badge {
+    display: inline-block;
+    padding: 0.3rem 0.8rem;
+    border-radius: 1rem;
+    font-weight: 600;
+    font-size: 0.85rem;
+    text-align: center;
+    color: #fff;
+    white-space: nowrap;
+}
+
+/* 불편 사항 상태 색상 정의 */
+.status-접수대기 {
+    background-color: #ffc107;
+    /* 노랑 */
+    color: #333;
+}
+
+.status-처리중 {
+    background-color: #004B8D;
+    /* 파랑 */
+}
+
+.status-완료 {
+    background-color: #28a745;
+    /* 초록 */
+}
+
+.status-취소 {
+    background-color: #dc3545;
+    /* 빨강 */
+}
+
+/* 7. 로딩 / 에러 / 데이터 없음 */
+#no-history,
+.loading-message,
+.error-message {
+    width: 100%;
+    text-align: center;
+    padding: 4rem 1rem;
+    color: #6c757d;
+    font-size: 1.1rem;
+    font-weight: 500;
+    background-color: #f8f9fa;
+    border-radius: 8px;
+}
+
+.error-message {
+    color: #dc3545;
+    background-color: #fef2f2;
+}
+
+.retry-button {
+    margin-top: 1rem;
+    padding: 0.6rem 1.2rem;
+    background-color: #004B8D;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.retry-button:hover {
+    background-color: #003a6e;
+}
+
+
+/* --- 8. 모달 스타일 --- */
+.modal-overlay {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
+.modal-content {
+    background-color: #fff;
+    padding: 2rem;
+    border-radius: 16px;
+    width: 90%;
+    max-width: 500px;
+    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
+    position: relative;
+    max-height: 90vh;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.modal-title {
+    color: #004B8D;
+    border-bottom: 2px solid #f0f0f0;
+    padding-bottom: 1rem;
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    font-size: 1.5rem;
+    font-weight: 700;
+    text-align: center;
+    width: 100%;
+}
+
+.close-btn {
+    color: #aaa;
+    position: absolute;
+    top: 1rem;
+    right: 1.5rem;
+    font-size: 2rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: color 0.19s;
+}
+
+.close-btn:hover,
+.close-btn:focus {
+    color: #000;
+}
+
+#modal-details {
+    width: 100%;
+}
+
+/* 9. 모달 내부 상세 */
+.detail-item {
+    margin-bottom: 0.75rem;
+    border-bottom: 1px solid #f7f7f7;
+    padding-bottom: 0.75rem;
+    width: 100%;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    font-size: 1rem;
+    line-height: 1.6;
+}
+
+.detail-item strong {
+    display: inline-block;
+    min-width: 90px;
+    color: #004B8D;
+    font-weight: 600;
+}
+
+/* ⭐️ 관리자 답변/처리 내용 박스 스타일 */
+.admin-note-box {
+    flex-direction: column;
+    align-items: flex-start !important;
+    border-top: 1px solid #ddd;
+    padding-top: 1rem;
+    margin-top: 1rem;
+    padding-bottom: 0 !important;
+    border-bottom: none !important;
+}
+
+.admin-note-box strong {
+    color: #004B8D;
+    width: 100%;
+    margin-bottom: 0.5rem;
+    font-size: 1.1rem;
+}
+
+.admin-note-box p {
+    margin: 0;
+    padding: 0.75rem;
+    border: 1px solid #c3e6cb;
+    width: 100%;
+    border-radius: 8px;
+    background-color: #e6f7e9;
+    white-space: pre-wrap;
+    box-sizing: border-box;
+    color: #218838;
+    font-size: 1rem;
+}
+
+
+/* 이미지 항목 wrapper 스타일 */
+.detail-item.image-item {
+    flex-direction: column;
+    align-items: flex-start !important;
+    padding-top: 1rem;
+    border-top: 1px solid #f0f0f0;
+}
+
+.detail-item.image-item strong {
+    width: 100%;
+    margin-bottom: 0.5rem;
+}
+
+.image-preview-wrapper {
+    width: 100%;
+    text-align: center;
+    background-color: #f8f8f8;
+    border-radius: 8px;
+    padding: 1rem;
+    box-sizing: border-box;
+}
+
+.complaint-image-preview {
+    max-width: 100%;
+    max-height: 250px;
+    height: auto;
+    border-radius: 6px;
+    object-fit: contain;
+    display: block;
+    margin: 0 auto;
+}
+
+/* 취소 사유 박스 */
+.cancel-reason-box {
+    flex-direction: column;
+    align-items: flex-start !important;
+    border-top: 1px solid #ddd;
+    padding-top: 1rem;
+    margin-top: 1rem;
+}
+
+.cancel-reason-box strong {
+    color: #dc3545;
+    width: 100%;
+    margin-bottom: 0.5rem;
+}
+
+.cancel-reason-box p {
+    margin: 0;
+    padding: 0.75rem;
+    border: 1px solid #eee;
+    width: 100%;
+    border-radius: 8px;
+    background-color: #f8f8f8;
+    white-space: pre-wrap;
+    box-sizing: border-box;
+}
+
+
+/* 10. 모달 버튼 */
+.modal-buttons {
+    margin-top: 2rem;
+    display: flex;
+    gap: 0.75rem;
+    justify-content: flex-end;
+    width: 100%;
+}
+
+.cancel-btn,
+.confirm-btn {
+    padding: 0.6rem 1.2rem;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.cancel-btn {
+    background-color: #f8f9fa;
+    color: #dc3545;
+    border: 1px solid #f5c2c7;
+}
+
+.cancel-btn:hover:not(:disabled) {
+    background-color: #dc3545;
+    color: #fff;
+}
+
+.confirm-btn {
+    background-color: #28a745;
+    color: #fff;
+}
+
+.confirm-btn:hover {
+    background-color: #218838;
+}

--- a/src/pages/ComplaintHistoryPage.jsx
+++ b/src/pages/ComplaintHistoryPage.jsx
@@ -1,0 +1,306 @@
+import React, { useState, useEffect } from 'react';
+import './ComplaintHistoryPage.css';
+import { BsArrowLeft, BsListCheck } from 'react-icons/bs';
+
+const API_BASE_URL = 'http://localhost:5050/api';
+
+const ComplaintHistoryPage = ({ onNavigate }) => {
+    const [complaints, setComplaints] = useState([]);
+    const [selectedComplaint, setSelectedComplaint] = useState(null);
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        fetchComplaints(); // ⭐️ 실제 API 호출 함수
+    }, []);
+
+    const fetchComplaints = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const token = localStorage.getItem('authToken');
+            if (!token) {
+                throw new Error('로그인이 필요합니다.');
+            }
+
+            // ⭐️ 실제 API 엔드포인트 호출
+            const response = await fetch(`${API_BASE_URL}/complaints/my`, {
+                headers: {
+                    'Authorization': `Bearer ${token}`
+                }
+            });
+
+            if (response.status === 401 || response.status === 403) {
+                throw new Error('인증에 실패했습니다. 다시 로그인해주세요.');
+            }
+            if (!response.ok) throw new Error('서버 응답 오류');
+
+            const data = await response.json();
+
+            const updatedComplaints = data.map(complaint => ({
+                ...complaint,
+                displayStatus: getComplaintDisplayStatus(complaint)
+            }));
+
+            updatedComplaints.sort((a, b) => {
+                const dateA = new Date(a.createdAt);
+                const dateB = new Date(b.createdAt);
+                return dateB - dateA; // 최신순
+            });
+
+            setComplaints(updatedComplaints);
+        } catch (err) {
+            setError(err.message || '불편 사항 목록을 불러오는 데 실패했습니다.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const getComplaintDisplayStatus = (complaint) => {
+        switch (complaint.status) {
+            case '접수대기': return '접수대기';
+            case '처리중': return '처리중';
+            case '완료': return '완료';
+            case '취소': return '취소';
+            default: return '접수대기';
+        }
+    };
+
+    const handleRowClick = (complaint) => {
+        setSelectedComplaint(complaint);
+        setIsModalOpen(true);
+    };
+
+    const closeModal = () => {
+        setIsModalOpen(false);
+        setSelectedComplaint(null);
+    };
+
+    const handleCancel = async () => {
+        if (!selectedComplaint || selectedComplaint.status === '완료' || selectedComplaint.status === '취소') return;
+
+        if (!window.confirm('접수하신 불편 사항을 취소하시겠습니까?')) {
+            return;
+        }
+
+        try {
+            const token = localStorage.getItem('authToken');
+            const complaintId = selectedComplaint.id;
+
+            // ⭐️ 실제 API 호출
+            const response = await fetch(`${API_BASE_URL}/complaints/${complaintId}/cancel`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${token}`
+                },
+            });
+
+            if (!response.ok) throw new Error('불편 사항 취소에 실패했습니다.');
+
+            const updatedComplaints = complaints.map(c =>
+                c.id === complaintId
+                    ? { ...c, status: '취소', displayStatus: '취소', cancelReason: '사용자 요청 취소' }
+                    : c
+            );
+            setComplaints(updatedComplaints);
+            alert('불편 사항 접수가 취소되었습니다.');
+            closeModal();
+
+        } catch (err) {
+            alert(`불편 사항 취소 중 오류가 발생했습니다: ${err.message}`);
+        }
+    };
+
+
+    const renderContent = () => {
+        if (loading) {
+            return (
+                <div className="loading-message">
+                    데이터를 불러오는 중입니다...
+                </div>
+            );
+        }
+
+        if (error) {
+            return (
+                <>
+                    <p className="error-message">{error}</p>
+                    <button className="retry-button" onClick={fetchComplaints}>
+                        다시 시도
+                    </button>
+                </>
+            );
+        }
+
+        if (complaints.length === 0) {
+            return (
+                <p id="no-history">
+                    아직 접수하신 불편 사항 내역이 없습니다.
+                </p>
+            );
+        }
+
+        return (
+            <table className="history-table">
+                <thead>
+                    <tr>
+                        <th>상태</th>
+                        <th>접수일</th>
+                        <th>유형</th>
+                        <th>제목</th>
+                        <th>신청자</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {complaints.map((complaint) => (
+                        <tr key={complaint.id} onClick={() => handleRowClick(complaint)}>
+                            <td>
+                                <span className={`status-badge status-${complaint.displayStatus}`}>
+                                    {complaint.displayStatus}
+                                </span>
+                            </td>
+                            <td>{complaint.createdAt ? new Date(complaint.createdAt).toLocaleDateString() : '날짜 정보 없음'}</td>
+                            <td>{complaint.category}</td>
+                            <td>{complaint.title}</td>
+                            <td>{complaint.applicantName}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        );
+    };
+
+    return (
+        <div className="history-page-container">
+            {/* 뒤로가기 버튼: ComplaintMenuPage로 이동 */}
+            <button
+                className="back-button"
+                onClick={() => onNavigate('complaintMenuPage')}
+            >
+                <BsArrowLeft size={16} />
+                뒤로
+            </button>
+            <div className="top-title">
+                <h1 className="page-title">
+                    <BsListCheck size={28} style={{ marginRight: '10px', verticalAlign: 'middle' }} />
+                    불편 사항 내역 조회
+                </h1>
+            </div>
+            <div className="history-container">
+                <div className="table-center-box">
+                    {renderContent()}
+                </div>
+            </div>
+
+            {/* 상세 정보 모달 */}
+            {isModalOpen && selectedComplaint && (
+                <div id="detail-modal" className="modal-overlay" onClick={closeModal}>
+                    <div className="modal-content" onClick={e => e.stopPropagation()}>
+                        <span className="close-btn" onClick={closeModal}>&times;</span>
+                        <h2 className="modal-title">불편 사항 상세</h2>
+
+                        <div id="modal-details">
+
+                            {selectedComplaint.status === '취소' ? (
+                                <>
+                                    <div className="detail-item"><strong>상태:</strong> <span className={`status-badge status-취소`}>취소</span></div>
+                                    <div className="detail-item"><strong>유형:</strong> {selectedComplaint.category}</div>
+                                    <div className="detail-item"><strong>제목:</strong> {selectedComplaint.title}</div>
+
+                                    <div className="detail-item" style={{ alignItems: 'flex-start' }}>
+                                        <strong>상세 내용:</strong>
+                                        <p style={{ margin: 0, flex: 1 }}>{selectedComplaint.details || '내용 없음'}</p>
+                                    </div>
+
+                                    {/* ⭐️ 관리자 답변/처리 내용 표시 */}
+                                    {selectedComplaint.managementNote && (
+                                        <div className="detail-item admin-note-box">
+                                            <strong>관리자 처리 내용</strong>
+                                            <p>{selectedComplaint.managementNote}</p>
+                                        </div>
+                                    )}
+
+                                    {/* ⭐️ 이미지 표시 */}
+                                    {selectedComplaint.imageUrl && (
+                                        <div className="detail-item image-item">
+                                            <strong>첨부 사진:</strong>
+                                            <div className="image-preview-wrapper">
+                                                <img
+                                                    src={selectedComplaint.imageUrl}
+                                                    alt="첨부된 불편 사항 사진"
+                                                    className="complaint-image-preview"
+                                                />
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    <div className="detail-item cancel-reason-box">
+                                        <strong>취소 사유</strong>
+                                        <p>{selectedComplaint.cancelReason || '사유 정보 없음'}</p>
+                                    </div>
+
+                                    <div className="modal-buttons">
+                                        <button className="confirm-btn" onClick={closeModal}>확인</button>
+                                    </div>
+                                </>
+                            ) : (
+                                <>
+                                    <div className="detail-item"><strong>상태:</strong> <span className={`status-badge status-${selectedComplaint.displayStatus}`}>{selectedComplaint.displayStatus}</span></div>
+                                    <div className="detail-item"><strong>유형:</strong> {selectedComplaint.category}</div>
+                                    <div className="detail-item"><strong>제목:</strong> {selectedComplaint.title}</div>
+
+                                    <div className="detail-item" style={{ alignItems: 'flex-start' }}>
+                                        <strong>상세 내용:</strong>
+                                        <p style={{ margin: 0, flex: 1 }}>{selectedComplaint.details || '내용 없음'}</p>
+                                    </div>
+
+                                    {/* ⭐️ 관리자 답변/처리 내용 표시 */}
+                                    {selectedComplaint.managementNote && (
+                                        <div className="detail-item admin-note-box">
+                                            <strong>관리자 처리 내용</strong>
+                                            <p>{selectedComplaint.managementNote}</p>
+                                        </div>
+                                    )}
+
+                                    {/* ⭐️ 이미지 표시 */}
+                                    {selectedComplaint.imageUrl && (
+                                        <div className="detail-item image-item">
+                                            <strong>첨부 사진:</strong>
+                                            <div className="image-preview-wrapper">
+                                                <img
+                                                    src={selectedComplaint.imageUrl}
+                                                    alt="첨부된 불편 사항 사진"
+                                                    className="complaint-image-preview"
+                                                />
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    <div className="detail-item" style={{ marginTop: '15px' }}><strong>신청자:</strong> {selectedComplaint.applicantName}</div>
+                                    <div className="detail-item"><strong>연락처:</strong> {selectedComplaint.contact}</div>
+                                    <div className="detail-item"><strong>접수일:</strong> {selectedComplaint.createdAt ? new Date(selectedComplaint.createdAt).toLocaleString() : '정보 없음'}</div>
+
+                                    <div className="modal-buttons">
+                                        {/* 취소 가능한 상태 (접수대기, 처리중)일 때만 취소 버튼 표시 */}
+                                        {(selectedComplaint.status === '접수대기' || selectedComplaint.status === '처리중') && (
+                                            <button className="cancel-btn" onClick={handleCancel}>
+                                                접수 취소
+                                            </button>
+                                        )}
+                                        <button className="confirm-btn" onClick={closeModal}>
+                                            확인
+                                        </button>
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default ComplaintHistoryPage;

--- a/src/pages/ComplaintMenuPage.css
+++ b/src/pages/ComplaintMenuPage.css
@@ -1,0 +1,197 @@
+/* ComplaintMenuPage.css */
+
+/* 1. 전체 컨테이너 (페이지 여백 및 정렬) */
+.complaint-menu-wrapper {
+    padding: 3rem 2rem;
+    min-height: 80vh;
+    width: 100%;
+    box-sizing: border-box;
+    font-family: 'Noto Sans KR', Arial, sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
+    /* ⭐️ back-button의 absolute 기준점 */
+}
+
+/* ⭐️ 2. 왼쪽 상단 '뒤로가기' 버튼 스타일 */
+.back-button {
+    position: absolute;
+    top: 1.5rem;
+    left: 1.5rem;
+    z-index: 10;
+    padding: 0.6rem 1.2rem;
+    background-color: #f8f9fa;
+    color: #333;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
+    transition: all 0.3s ease;
+}
+
+.back-button:hover {
+    background-color: #ffffff;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+}
+
+
+/* 3. 메인 페이지 헤더 스타일 */
+.main-page-header {
+    width: 100%;
+    max-width: 600px;
+    /* 메인 메뉴보다 약간 좁게 */
+    text-align: center;
+    margin-bottom: 4rem;
+    padding-top: 3rem;
+    /* ⭐️ 뒤로가기 버튼과 겹치지 않도록 조정 */
+}
+
+.main-page-title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: #004B8D;
+    /* 인하대 메인 색상 */
+    margin: 0;
+}
+
+.main-page-welcome {
+    font-size: 1.25rem;
+    color: #555;
+    margin-top: 0.75rem;
+}
+
+/* 4. 카드 그리드 (1:1 레이아웃 구현) */
+.menu-card-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+    width: 100%;
+    max-width: 600px;
+    margin: 0 auto;
+    flex-grow: 1;
+}
+
+/* 5. 카드 공통 스타일 */
+.menu-section {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+
+    background-color: #ffffff;
+    border: 1px solid #e9ecef;
+    border-radius: 16px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.03);
+
+    padding: 2rem;
+    transition: all 0.3s ease;
+    cursor: pointer;
+    text-align: center;
+    min-height: 280px;
+}
+
+/* 5.1 카드 호버 효과 */
+.menu-section:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 12px 24px rgba(0, 75, 141, 0.1);
+    /* 인하대 파란색 그림자 */
+}
+
+/* 6. 버튼/내부 요소 스타일 */
+.menu-button {
+    border: none;
+    background: none;
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+}
+
+.menu-icon-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    background-color: #f8f9fa;
+    transition: all 0.3s ease;
+    color: #555;
+    margin-bottom: 1rem;
+}
+
+.menu-text {
+    font-size: 1.4rem;
+    font-weight: 700;
+    text-align: center;
+    color: #333;
+    margin-bottom: 0.5rem;
+    transition: color 0.3s ease;
+}
+
+.menu-description {
+    font-size: 0.9rem;
+    color: #666;
+    text-align: center;
+    line-height: 1.6;
+}
+
+
+/* 7. 카드별 호버 시 색상 변경 테마 적용 */
+
+/* '불편 사항 접수' (주황 계열) */
+.menu-section.section-register:hover .menu-icon-wrapper {
+    background-color: #e67e22;
+    /* 주황색 */
+    color: #ffffff;
+}
+
+.menu-section.section-register:hover .menu-text {
+    color: #e67e22;
+}
+
+/* '불편 사항 내역' (보라 계열) */
+.menu-section.section-history:hover .menu-icon-wrapper {
+    background-color: #8e44ad;
+    /* 보라색 */
+    color: #ffffff;
+}
+
+.menu-section.section-history:hover .menu-text {
+    color: #8e44ad;
+}
+
+/* ⭐ 모바일 대응 */
+@media (max-width: 768px) {
+    .menu-card-grid {
+        /* 한 컬럼으로 변경 */
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+        max-width: 90%;
+        /* 모바일에서 너비 확보 */
+    }
+
+    .menu-section {
+        min-height: unset;
+    }
+
+    .main-page-title {
+        font-size: 2rem;
+    }
+
+    .main-page-welcome {
+        font-size: 1rem;
+    }
+}

--- a/src/pages/ComplaintMenuPage.jsx
+++ b/src/pages/ComplaintMenuPage.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import './ComplaintMenuPage.css';
+// ⭐️ 아이콘 import: 접수 (BsPencilSquare), 내역 (BsListCheck), 뒤로가기 (BsArrowLeft)
+import { BsPencilSquare, BsListCheck, BsArrowLeft } from 'react-icons/bs';
+
+const ComplaintMenuPage = ({ onNavigate }) => {
+
+    const handleSectionClick = (page) => {
+        onNavigate(page);
+    };
+
+    return (
+        // ⭐️ 클래스 이름: complaint-menu-wrapper
+        <div className="complaint-menu-wrapper">
+
+            {/* ⭐️ 왼쪽 상단 '뒤로가기' 버튼 (수정된 위치) */}
+            <button
+                className="back-button" // back-button 클래스 사용
+                onClick={() => handleSectionClick('main')} // 메인 메뉴(mainPages)로 이동
+            >
+                <BsArrowLeft size={16} />
+                뒤로
+            </button>
+
+            {/* 헤더: 메인 페이지 UI와 유사하게 구성 */}
+            <header className="main-page-header">
+                <h1 className="main-page-title">
+                    불편 사항 접수 메뉴
+                </h1>
+                <p className="main-page-welcome">
+                    원하는 불편 사항 관련 서비스를 선택하세요.
+                </p>
+            </header>
+
+            {/* ⭐️ 카드 그리드 (1:1 레이아웃) */}
+            <main className="menu-card-grid">
+
+                {/* '불편 사항 접수' 섹션 (카드 1) */}
+                <div
+                    className="menu-section section-register"
+                    onClick={() => handleSectionClick('complaintPage')} // ⭐️ 접수 페이지로 이동
+                >
+                    <button className="menu-button">
+                        <div className="menu-icon-wrapper">
+                            <BsPencilSquare size={40} />
+                        </div>
+                        <span className="menu-text">불편 사항 접수</span>
+                        <p className="menu-description">
+                            시설 이용 또는 예약 시스템 관련 불편 사항을 새로 접수합니다.
+                        </p>
+                    </button>
+                </div>
+
+                {/* '불편 사항 내역' 섹션 (카드 2) */}
+                <div
+                    className="menu-section section-history"
+                    onClick={() => handleSectionClick('complaintHistoryPage')} // ⭐️ 내역 페이지로 이동
+                >
+                    <button className="menu-button">
+                        <div className="menu-icon-wrapper">
+                            <BsListCheck size={40} />
+                        </div>
+                        <span className="menu-text">불편 사항 내역</span>
+                        <p className="menu-description">
+                            내가 접수한 불편 사항의 처리 현황을 조회합니다.
+                        </p>
+                    </button>
+                </div>
+
+            </main>
+
+            {/* 하단 '메인으로 돌아가기' 버튼은 상단 버튼으로 대체되어 제거되었습니다. */}
+        </div>
+    );
+};
+
+export default ComplaintMenuPage;

--- a/src/pages/ComplaintPage.jsx
+++ b/src/pages/ComplaintPage.jsx
@@ -103,7 +103,7 @@ const ComplaintPage = ({ onNavigate }) => {
         <div className="complaint-page-container">
             {/* 뒤로가기 버튼 */}
             <button
-                onClick={() => onNavigate('main')}
+                onClick={() => onNavigate('complaintMenuPage')}
                 className="back-button"
                 disabled={loading}
             >

--- a/src/pages/MainPages.jsx
+++ b/src/pages/MainPages.jsx
@@ -63,7 +63,7 @@ const MainPages = ({ onNavigate }) => {
         {/* '불편 사항 접수' 섹션 (작은 카드 2) */}
         <div
           className="reservation-section section-complaint"
-          onClick={() => handleSectionClick('complaintPage')}
+          onClick={() => handleSectionClick('complaintMenuPage')}
         >
           <button className="menu-button">
             <div className="menu-icon-wrapper">

--- a/src/pages/ReservationFormSelectPage.jsx
+++ b/src/pages/ReservationFormSelectPage.jsx
@@ -11,7 +11,7 @@ const ReservationFormSelectPage = ({ onNavigate }) => {
 
             {/* 뒤로가기 버튼 */}
             <button
-                onClick={() => onNavigate('mainPages')}
+                onClick={() => onNavigate('main')}
                 className="back-button"
             >
                 <BsArrowLeft size={16} />


### PR DESCRIPTION
추가에 따라서 중간다리 페이지인, ComplaintMenuPage가 생겼습니다.
이 페이지는 내역보기, 불편사항 접수를 담당합니다

0.사소한 버그를 수정했습니다.
ReservationFormSelectPage에서 뒤로가기를 누르면 login페이지로 가는 버그를 수정했습니다.

ComplaintPage는 이전과 같습니다.

ComplaintHistoryPage의 기능은 다음과 같습니다.
1. complainPage에서 입력한 내용을 보여줍니다 2.목록상태에서 보이는 정보는 다음과 같습니다.
상태	접수일 유형	제목 신청자
3. 상세 모달의 표시항목은 다음과 같습니다. 상태, 유형/제목 , 상세 내용, 관리자 처리 내용, 첨부 사진, 신청자, 연락처, 접수일, 취소 사유